### PR TITLE
Add run-portus.py to support batch-converting Alloy to SMTLIB++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,299 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python,intellij,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,intellij,visualstudiocode
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### VisualStudioCode ###
+.vscode/*
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+# End of https://www.toptal.com/developers/gitignore/api/python,intellij,visualstudiocode

--- a/run-portus.py
+++ b/run-portus.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""
+Run Portus on many files and output SMTLIB++.
+"""
+
+import argparse
+import os
+import os.path
+import shutil
+
+
+DEFAULT_ALLOY_JAR_LOCATION = (
+    '../org.alloytools.alloy/org.alloytools.alloy.dist/'
+    'target/org.alloytools.alloy.dist.jar'
+)
+DEFAULT_FORTRESS_JAR_DIR = '../org.alloytools.alloy/org.alloytools.fortress.core/libs'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Run Alloy files through Portus and dump them to SMTLIB++.')
+    parser.add_argument('--alloy-jar', '-j', default=DEFAULT_ALLOY_JAR_LOCATION, help='Path to the Alloy dist jar')
+    parser.add_argument('--fortress-jar-dir', '-f', default=DEFAULT_FORTRESS_JAR_DIR,
+        help='Path to the directory containing the Fortress jar and dependencies')
+    parser.add_argument('alloyfiles', nargs='+', help='Alloy files to run through Portus')
+    return parser.parse_args()
+
+
+def dump_file(alloy_jar_path: str, fortress_dir_path: str, alloy_filename: str):
+    # Run it through Portus manually
+    result = os.system(
+        "java -cp '{alloy_jar}{dir_sep}{fortress_dir}/*' -DfortressDumpToSmtlib=yes "
+        'edu.mit.csail.sdg.alloy4whole.SimpleCLI {alloy_filename}'.format(
+            alloy_jar=alloy_jar_path,
+            dir_sep=os.pathsep, # Windows uses a different separator
+            fortress_dir=fortress_dir_path,
+            alloy_filename=alloy_filename))
+    if result != 0:
+        raise RuntimeError('Alloy invocation returned {}'.format(result))
+    
+    # The above command output to a temporary file whose name is in .alloy.tmp
+    with open('.alloy.tmp', 'r') as output_file:
+        output = output_file.readlines()
+
+    # Delete the unwanted .alloy.tmp file
+    os.remove('.alloy.tmp')
+
+    # There should be one line that looks like "Output to: {filename}"
+    prefix = 'Output to: '
+    try:
+        smtlib_filename = next(line.strip()[len(prefix):] for line in output if line.startswith(prefix))
+    except StopIteration:
+        raise RuntimeError('No SMTLIB output filename found')
+
+    # Copy it to the Alloy file's directory
+    alloy_dirname = os.path.dirname(alloy_filename)
+    desired_smtlib_basename = os.path.basename(alloy_filename)
+    if desired_smtlib_basename.endswith('.als'):
+        desired_smtlib_basename = desired_smtlib_basename[:-len('.als')]
+    desired_smtlib_basename += '.smtlib'
+    smtlib_location = alloy_dirname + '/' + desired_smtlib_basename
+    shutil.copy(smtlib_filename, smtlib_location)
+    print('Dumped to', smtlib_location)
+
+
+def main():
+    args = parse_args()
+    for alloy_filename in args.alloyfiles:
+        print('Running {} through Portus...'.format(alloy_filename))
+        try:
+            dump_file(args.alloy_jar, args.fortress_jar_dir, alloy_filename)
+        except Exception as e:
+            print('Error:', e)
+
+
+if __name__ == '__main__':
+    main()

--- a/run-portus.py
+++ b/run-portus.py
@@ -57,7 +57,7 @@ def dump_file(alloy_jar_path: str, fortress_dir_path: str, alloy_filename: str):
     desired_smtlib_basename = os.path.basename(alloy_filename)
     if desired_smtlib_basename.endswith('.als'):
         desired_smtlib_basename = desired_smtlib_basename[:-len('.als')]
-    desired_smtlib_basename += '.smtlib'
+    desired_smtlib_basename += '.smttc'
     smtlib_location = alloy_dirname + '/' + desired_smtlib_basename
     shutil.copy(smtlib_filename, smtlib_location)
     print('Dumped to', smtlib_location)


### PR DESCRIPTION
run-portus.py will run several Alloy files through Portus and dump them to Fortress's SMTLIB++. Also added a gitignore from gitignore.io.

Usage: `python run-portus.py test1.als test2.als`. Assumes it's being run from the root of the portus-tests repo which is cloned in a directory adjacent to the Portus repo (WatForm/org.alloytools.alloy on the `portus` branch). You'll have to run `./gradlew build` in that directory first so the JARs are available. If you're in a different folder structure, pass the path to `org.alloytools.alloy.dist.jar` in `-j` and the path to the `org.alloytools.fortress.core/libs` folder in `-f`.