### PR TITLE
Finalize option configurations for evaluation

### DIFF
--- a/testrunner/util.py
+++ b/testrunner/util.py
@@ -17,22 +17,16 @@ import itertools
 T = TypeVar('T')
 
 # Include -b to increase bitwidth as required
+# For correctness, use -c instead of -r
 PORTUS_METHODS = {
-    'portus': '-r -compiler constants',
     'kodkod': '-rk',
-    'unoptimized': '-r -disable-all-opts -disable-func-opts -b -compiler constants',  # updated with -disable-function-opt as of 15/4/2024
-    'sort-mem-pred': '-r -disable-simple-scalar-opt -disable-one-sig-opt -disable-join-opt -disable-func-opt -b -use-card-sap',
-    #'one-sig': '-r compile constants -disable-join-opt -disable-ordering-opt -disable-mem-pred-opt -disable-partition-sp -disable-sum-defn-opt',
-    'join': '-r -disable-simple-scalar-opt -disable-one-sig-opt -disable-mem-pred-opt -disable-partition-sp -disable-func-opt -b -use-card-sap',
-    'func-opt': '-r -disable-simple-scalar-opt -disable-one-sig-opt -disable-mem-pred-opt -disable-partition-sp -disable-join-opt -b -use-card-sap',
-    'scalar': '-r -disable-mem-pred-opt -disable-partition-sp -disable-join-opt -b -use-card-sap',
-    'constants': '-r -disable-simple-scalar-opt -disable-one-sig-opt -disable-join-opt -disable-func-opt',
-    'card': '-r -b -use-card-sap',
+    'portus-full': '-r',
+    'portus-minus-partition-mem-pred': '-r -disable-partition-sp -disable-mem-pred-opt',
+    'portus-minus-scalar': '-r -disable-simple-scalar-opt -disable-one-sig-opt -disable-join-opt',
+    'portus-minus-functions': '-r -disable-func-opt',
+    'portus-minus-constants-axioms': '-r -b -use-card-sap',
+    'unoptimized': '-r -disable-all-opts -disable-func-opt -b -use-card-sap',
     'claessen': '-r -compiler constants-claessen',
-    #'ordering': '-r compile constants -one-sig-opt -disable-join-opt -disable-mem-pred-opt -disable-partition-sp -disable-sum-defn-opt',
-    #'mem-pred': '-r compile constants -one-sig-opt -disable-join-opt -disable-ordering-opt -disable-partition-sp -disable-sum-defn-opt',
-    #'partition': '-r compile constants -one-sig-opt -disable-join-opt -disable-ordering-opt -disable-mem-pred-opt -disable-sum-defn-opt',
-    #'sum-defn': '-r compile constants -one-sig-opt -disable-join-opt -disable-ordering-opt -disable-mem-pred-opt -disable-partition-sp',
 }
 
 class Satisfiablity(str, Enum):


### PR DESCRIPTION
I tried to give the configurations reasonable names:
- `kodkod`: run Kodkod
- `portus-full`: run Portus with all optimizations
- `portus-minus-partition-mem-pred`: run Portus with all optimizations except the partition sort policy/membership predicate optimization
- `portus-minus-scalar`: run Portus with all optimizations except the simple scalar, one sig, and join optimizations
- `portus-minus-functions`: run Portus with all optimizations except the function optimization
- `portus-minus-constants-axioms`: run Portus with all optimizations except use the cardinality-based scope axioms instead of the constants scope axioms
- `unoptimized`: run Portus with no optimizations
- `claessen`: run Portus with all optimizations and the constants-claessen compiler (using Claessen TC instead of Eijck)