### PR TITLE
Clear the cache before each run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ We assume the following are already installed:
 
 
 5. Here are the tests we ran:
-    `python3 eval_portus.py -m portus kodkod`
+    `python3 eval_portus.py -m portus-full kodkod`
     ...
 
 6. Run various executions of portus and kodkod in the virtual environment.  The python script eval_portus.py has lots of options.  Each execution of the script runs specified versions of portus and/or kodkod on the expert-models a certain number of iterations with a timeout and outputs the times to a .csv output file.

--- a/eval_portus.py
+++ b/eval_portus.py
@@ -237,6 +237,7 @@ if __name__ == '__main__':
             fields_from_timeout=timeout_values,
             # output CSV file contains all non_ignored fields
             ignore_fields=ignore_fields,
+            clear_cache=True
         )
         
         if args.verbose:

--- a/eval_portus.py
+++ b/eval_portus.py
@@ -102,7 +102,7 @@ models_and_cmds = tr.CSVOption('models_and_cmds', models_command_file)
 
 
 
-methods = util.PORTUS_METHODS
+methods = PORTUS_METHODS
 method_names = list(methods.keys())
 
 if __name__ == '__main__':

--- a/portus-eval-script.py
+++ b/portus-eval-script.py
@@ -150,5 +150,6 @@ with open(output_file_name(filename_suffix), 'w') as output_file:
         # output CSV file contains all non_ignored fields
         result_fields = result_fields,
         ignore_fields=ignore_fields,
+        clear_cache=True,
     )  
     runner.run(ITERATIONS, SKIP, FORCE_HEADER)


### PR DESCRIPTION
`portus-evaluation` component of the testrunner PR which clears the caches before each run: https://github.com/WatForm/testrunner/pull/1.

Also fixed a couple errors in the code and docs.